### PR TITLE
fix option import: No results from Akeneo

### DIFF
--- a/Job/Option.php
+++ b/Job/Option.php
@@ -151,7 +151,11 @@ class Option extends Import
         foreach ($attributes as $attribute) {
             if ($attribute['type'] == 'pim_catalog_multiselect' || $attribute['type'] == 'pim_catalog_simpleselect') {
                 /** @var PageInterface $options */
-                $options    = $this->akeneoClient->getAttributeOptionApi()->listPerPage($attribute['code']);
+                $options = $this->akeneoClient->getAttributeOptionApi()->listPerPage($attribute['code']);
+                if (empty($options->getItems())) {
+                    continue;
+                }
+
                 $hasOptions = true;
 
                 break;


### PR DESCRIPTION
Currently, if the first option which has a valid type has no options, the whole import is terminated. This happens because the foreach is terminated after the first attribute with valid type.
With the fix, the foreach is continued until there is an attribute with options or the foreach has finished.