### PR TITLE
Fix ‘This product doesn't exist.’

### DIFF
--- a/Job/Attribute.php
+++ b/Job/Attribute.php
@@ -356,6 +356,11 @@ class Attribute extends Import
                 'attribute_code' => $row['code'],
                 'frontend_label' => $frontendLabel,
                 'is_global'      => $global,
+                'backend_type'   => $row['backend_type'],
+                'frontend_input' => $row['frontend_input'],
+                'backend_model'  => $row['backend_model'],
+                'source_model'   => $row['source_model'],
+                'frontend_model' => $row['frontend_model'],
             ];
             foreach ($columns as $column => $def) {
                 if (!$def['only_init']) {


### PR DESCRIPTION
Currently, when you import the attributes the backend_type is not updated/inserted into the eav_attribute table. Because of that the default backend_type ‘static’ is used. But with backend_type ‘static’ Magento tries to get the information from catalog_product_entity table where there is no value column, so a SQL error occurs.
By adding backend_type as well as other attribute settings, which are explicitly mapped in matchType(), Magento searches in the right table i.e. catalog_product_entity_varchar for the attribute value.