### PR TITLE
Changed usage of entity-type id as attribute-set id for categories

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -510,6 +510,19 @@ class Config extends AbstractHelper
     }
 
     /**
+     * Get default attribute-set id for given entity
+     *
+     * @param $entity
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getDefaultAttributeSetId($entity)
+    {
+        return $this->eavConfig->getEntityType($entity)->getDefaultAttributeSetId();
+    }
+
+    /**
      * Retrieve attribute by code
      *
      * @param string $entityType

--- a/Job/Category.php
+++ b/Job/Category.php
@@ -396,7 +396,7 @@ class Category extends Import
         /** @var array $values */
         $values = [
             'entity_id'        => '_entity_id',
-            'attribute_set_id' => new Expr($this->configHelper->getEntityTypeId(CategoryModel::ENTITY)),
+            'attribute_set_id' => new Expr($this->configHelper->getDefaultAttributeSetId(CategoryModel::ENTITY)),
             'parent_id'        => 'parent_id',
             'updated_at'       => new Expr('now()'),
             'path'             => 'path',


### PR DESCRIPTION
The original implementation works without problems for plain installations of Magento 2 as both entity-type id and attribute-set id are identical then.
But if data was e.g. migrated from Magento 1 those two values are not necessarily identical anymore, using the original implementation then leads to wrong attribute-set ids in imported categories.
Those wrong attribute-set ids then cause some confusion in Magento like missing category-names.