### PR TITLE
[config] Fix LocalizedException 

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -25,13 +25,11 @@
                 <completeness_type>=</completeness_type>
                 <completeness_value>100</completeness_value>
                 <status>1</status>
+                <updated_mode>SINCE LAST N DAYS</updated_mode>
             </products_filters>
             <product>
                 <url_generation_enabled>1</url_generation_enabled>
             </product>
-            <products_filters>
-                <updated_mode>SINCE LAST N DAYS</updated_mode>
-            </products_filters>
             <category>
                 <is_active>1</is_active>
                 <include_in_menu>1</include_in_menu>


### PR DESCRIPTION
Fix LocalizedException when project module redefine <products_filters> node in config.xml:
"Magento\Framework\Exception\LocalizedException: More than one node matching the query: /config/default/pimgento/products_filters"